### PR TITLE
page-service: redirect / to /task-management

### DIFF
--- a/page-service/src/main/java/ru/tasktracking/pageservice/controller/PageController.java
+++ b/page-service/src/main/java/ru/tasktracking/pageservice/controller/PageController.java
@@ -10,6 +10,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 @RequiredArgsConstructor
 public class PageController {
 
+    @GetMapping("/")
+    public String root() {
+        return "redirect:/task-management";
+    }
+
     @GetMapping("/login")
     public String getAuthPage() {
         return "login";


### PR DESCRIPTION
Adds a `GET /` handler that redirects to `/task-management` so opening the service root in a browser does not hit the static resource handler and return an error JSON.