### PR TITLE
Enforce Java 17 builds and refresh README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,84 @@
-# Task tracking and management system
-## Introduction
-The Task Tracking Application is a comprehensive solution for managing tasks efficiently. It allows users to create, 
-edit, and delete tasks, receive notifications about deadlines, categorize tasks, and collaborate within a team.
-The application also offers detailed reports and statistics to help users keep track of their productivity.
+# Task Management
 
-## Features
- - **Task Management:** Create, edit, delete tasks.
- - **Notifications:** Receive reminders about task deadlines.
- - **Categorization and Tagging:** Organize tasks using categories and tags.
- - **Team Collaboration:** Assign tasks to team members and work together.
- - **Reports and Statistics:** Generate reports and view statistics on task completion.
+Микросервисная система для управления задачами, пользователями, досками и комментариями.
+Сервисы регистрируются в Eureka, конфигурация централизована через Config Server, межсервисное взаимодействие выполняется по HTTP/Feign.
 
-## Architectural Patterns
- - **Microservices Architecture:** The application is built using a microservices architecture to ensure scalability and maintainability.
- - **REST API:** Services interact with each other through RESTful APIs.
+## Состав проекта
 
-## Application Architecture
-The Task Tracking Application consists of the following services:
- - **Page Service:** Provides the user interface for interacting with the application.
- - **Task Service:** Manages tasks and their statuses.
- - **User Service:** Manages user information.
- - **Gateway Service:** Redirects to the target services and performs authentication and authorization.
- - **Batch Service:** Initializes data and can be used as an alternative interface using the Spring Shell
- - **Board Service:** Manages boards.
- - **Comment Service:** Manages comments.
- - **Config Server:** Manages the configurations of the application microservices
- - **Discovery Server:** Performs registration of services and provides information about them.
+- `config-server` — централизованная конфигурация.
+- `discovery-server` — service discovery (Eureka).
+- `gateway-service` — единая точка входа и маршрутизация.
+- `page-service` — web UI.
+- `user-service` — управление пользователями.
+- `task-service` — управление задачами.
+- `board-service` — управление досками.
+- `comment-service` — управление комментариями.
+- `batch-service` — batch/shell-операции и инициализация данных.
+- `mongo` + `mongo-express` — хранилище и UI для MongoDB.
 
-## Contact
-For any inquiries or feedback, please contact dmitry.shadrin.alex1989@gmail.com.
- 
- 
+## Требования
+
+- Docker + Docker Compose.
+- Для локальной сборки сервисов без Docker: JDK 17.
+  - Во всех сервисах включен `maven-enforcer-plugin`, сборка на другом JDK будет остановлена.
+
+## Быстрый старт (рекомендуется)
+
+Из корня репозитория:
+
+```bash
+docker compose build --no-cache
+docker compose up -d
+docker compose ps
+```
+
+Остановка:
+
+```bash
+docker compose down --remove-orphans
+```
+
+## Полезные команды
+
+Логи конкретного сервиса:
+
+```bash
+docker compose logs -f comment-service
+```
+
+Проверка health:
+
+```bash
+curl http://localhost:8888/actuator/health   # config-server
+curl http://localhost:8761/actuator/health   # discovery-server
+curl http://localhost:8080/actuator/health   # gateway-service
+```
+
+## Порты сервисов
+
+- `8080` — `gateway-service`
+- `8081` — `mongo-express`
+- `8085` — `page-service`
+- `8086` — `user-service`
+- `8087` — `task-service`
+- `8088` — `comment-service`
+- `8089` — `board-service`
+- `8090` — `batch-service`
+- `8761` — `discovery-server`
+- `8888` — `config-server`
+- `27017` — `mongo`
+
+## Локальная сборка без Docker
+
+Если нужно собрать JAR вручную:
+
+```bash
+cd <service-directory>
+mvn -DskipTests clean package
+```
+
+Для сервисов с Maven Wrapper можно использовать `./mvnw`.
+
+## Контакты
+
+Вопросы и предложения: `dmitry.shadrin.alex1989@gmail.com`.

--- a/batch-service/README.md
+++ b/batch-service/README.md
@@ -1,3 +1,50 @@
-# Task tracking and management system
-## Service: Batch Service
-Initializes data and can be used as an alternative interface using the Spring Shell
+# Batch Service
+
+Сервис пакетной обработки и вспомогательных shell-операций.
+
+## Назначение
+
+- запуск batch-процессов;
+- инициализация/подготовка данных;
+- альтернативный интерфейс через Spring Shell.
+
+## Технологии
+
+- Spring Boot
+- Spring Batch
+- Spring Shell
+- Spring Data MongoDB
+- Spring Cloud Config Client
+- Eureka Client
+
+## Порт и healthcheck
+
+- Порт: `8090`
+- Health: `GET http://localhost:8090/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+./mvnw -DskipTests clean package
+```
+
+Если wrapper недоступен:
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d batch-service
+docker compose logs -f batch-service
+```

--- a/batch-service/pom.xml
+++ b/batch-service/pom.xml
@@ -17,7 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring.shell.version>3.1.3</spring.shell.version>
         <opencsv.version>5.8</opencsv.version>
         <spring-cloud.version>2023.0.1</spring-cloud.version>
@@ -123,6 +124,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[17,18)</version>
+                                    <message>batch-service must be built with JDK 17.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/board-service/README.md
+++ b/board-service/README.md
@@ -1,3 +1,50 @@
-# Task tracking and management system
-## Service: Board Service
-Manages boards.
+# Board Service
+
+Сервис управления досками.
+
+## Назначение
+
+- операции с досками (создание, изменение, получение);
+- хранение данных в MongoDB;
+- интеграция в общую микросервисную инфраструктуру.
+
+## Технологии
+
+- Spring Boot
+- Spring Web
+- Spring Data MongoDB
+- Spring Cloud Config Client
+- Eureka Client
+- OpenFeign
+
+## Порт и healthcheck
+
+- Порт: `8089`
+- Health: `GET http://localhost:8089/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+./mvnw -DskipTests clean package
+```
+
+Если wrapper недоступен:
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d board-service
+docker compose logs -f board-service
+```

--- a/board-service/pom.xml
+++ b/board-service/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring-cloud.version>2023.0.1</spring-cloud.version>
         <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
         <checkstyle.version>10.11.0</checkstyle.version>
@@ -100,6 +100,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[17,18)</version>
+                                    <message>board-service must be built with JDK 17.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/comment-service/README.md
+++ b/comment-service/README.md
@@ -1,3 +1,57 @@
-# Task tracking and management system
-## Service: Comment Service
-Manages comments.
+# Comment Service
+
+Сервис комментариев для задач.
+
+## Назначение
+
+- хранение и выдача комментариев;
+- создание и обновление комментариев;
+- интеграция с `user-service` и `task-service` через Feign-клиенты.
+
+## Технологии
+
+- Spring Boot
+- Spring Web
+- Spring Data MongoDB
+- Spring Cloud Config Client
+- Eureka Client
+- OpenFeign
+
+## Порт и healthcheck
+
+- Порт: `8088`
+- Health: `GET http://localhost:8088/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+./mvnw -DskipTests clean package
+```
+
+Если wrapper недоступен:
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d comment-service
+docker compose logs -f comment-service
+```
+
+## Основные REST endpoints
+
+- `GET /api/comment`
+- `GET /api/comment/{id}`
+- `POST /api/comment`
+- `PUT /api/comment/{id}`

--- a/comment-service/pom.xml
+++ b/comment-service/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring-cloud.version>2023.0.1</spring-cloud.version>
         <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
         <checkstyle.version>10.11.0</checkstyle.version>
@@ -100,6 +100,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[17,18)</version>
+                                    <message>comment-service must be built with JDK 17.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/config-server/README.md
+++ b/config-server/README.md
@@ -1,3 +1,39 @@
-# Task tracking and management system
-## Service: Config Server
-Manages the configurations of the application microservices
+# Config Server
+
+Централизованный сервер конфигураций для всех микросервисов.
+
+## Назначение
+
+- выдача конфигурации сервисам при старте и во время работы;
+- единая точка управления application-конфигами;
+- интеграция с удаленным конфигурационным репозиторием.
+
+## Технологии
+
+- Spring Boot
+- Spring Cloud Config Server
+
+## Порт и healthcheck
+
+- Порт: `8888`
+- Health: `GET http://localhost:8888/actuator/health`
+
+## Зависимости при запуске
+
+- внешнее подключение к конфигурационному Git-репозиторию (если настроено);
+- другие сервисы зависят от `config-server`.
+
+## Локальная сборка
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d config-server
+docker compose logs -f config-server
+```

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -18,8 +18,8 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<spring-cloud.version>2023.0.0</spring-cloud.version>
 		<checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
 		<checkstyle.version>10.11.0</checkstyle.version>
@@ -61,6 +61,27 @@
 	<build>
 		<finalName>${project.artifactId}</finalName>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[17,18)</version>
+									<message>config-server must be built with JDK 17.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/discovery-server/README.md
+++ b/discovery-server/README.md
@@ -1,3 +1,40 @@
-# Task tracking and management system
-## Service: Discovery Server
-Performs registration of services and provides information about them.
+# Discovery Server
+
+Сервис регистрации и обнаружения сервисов (Eureka).
+
+## Назначение
+
+- регистрация микросервисов;
+- хранение и выдача информации о доступных инстансах;
+- поддержка service-to-service коммуникаций через service discovery.
+
+## Технологии
+
+- Spring Boot
+- Spring Cloud Netflix Eureka Server
+- Spring Cloud Config Client
+
+## Порт и healthcheck
+
+- Порт: `8761`
+- Health: `GET http://localhost:8761/actuator/health`
+- UI Eureka: `http://localhost:8761`
+
+## Зависимости при запуске
+
+- `config-server` (обязателен).
+
+## Локальная сборка
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d discovery-server
+docker compose logs -f discovery-server
+```

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -18,8 +18,8 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<spring-cloud.version>2023.0.0</spring-cloud.version>
 		<checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
 		<checkstyle.version>10.11.0</checkstyle.version>
@@ -90,6 +90,27 @@
 	<build>
 		<finalName>${project.artifactId}</finalName>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[17,18)</version>
+									<message>discovery-server must be built with JDK 17.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/gateway-service/README.md
+++ b/gateway-service/README.md
@@ -1,3 +1,43 @@
-# Task tracking and management system
-## Service: Gateway Service
-Redirects to the target services and performs authentication and authorization.
+# Gateway Service
+
+API Gateway системы.
+
+## Назначение
+
+- единая точка входа для клиентских запросов;
+- маршрутизация запросов к внутренним сервисам;
+- базовый security-фильтр и инфраструктурная обвязка.
+
+## Технологии
+
+- Spring Boot
+- Spring Cloud Gateway (MVC)
+- Spring Security
+- Spring Cloud Config Client
+- Eureka Client
+
+## Порт и healthcheck
+
+- Порт: `8080`
+- Health: `GET http://localhost:8080/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d gateway-service
+docker compose logs -f gateway-service
+```

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -18,8 +18,8 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<jsonwebtoken.version>0.9.1</jsonwebtoken.version>
 		<spring-cloud.version>2023.0.1</spring-cloud.version>
 		<checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
@@ -126,6 +126,27 @@
 	<build>
 		<finalName>${project.artifactId}</finalName>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[17,18)</version>
+									<message>gateway-service must be built with JDK 17.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/page-service/README.md
+++ b/page-service/README.md
@@ -1,3 +1,43 @@
-# Task tracking and management system
-## Service: Page Service
-Provides the user interface for interacting with the application.
+# Page Service
+
+Frontend/Web слой системы.
+
+## Назначение
+
+- пользовательский веб-интерфейс;
+- отображение данных из backend-сервисов;
+- orchestration запросов через инфраструктуру микросервисов.
+
+## Технологии
+
+- Spring Boot
+- Spring Web
+- Thymeleaf
+- Spring Cloud Config Client
+- Eureka Client
+
+## Порт и healthcheck
+
+- Порт: `8085`
+- Health: `GET http://localhost:8085/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d page-service
+docker compose logs -f page-service
+```

--- a/page-service/pom.xml
+++ b/page-service/pom.xml
@@ -18,8 +18,8 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<spring-cloud.version>2023.0.1</spring-cloud.version>
 		<checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
 		<checkstyle.version>10.11.0</checkstyle.version>
@@ -92,6 +92,27 @@
 	<build>
 		<finalName>${project.artifactId}</finalName>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[17,18)</version>
+									<message>page-service must be built with JDK 17.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/task-service/README.md
+++ b/task-service/README.md
@@ -1,3 +1,50 @@
-# Task tracking and management system
-## Service: Task Service
-Manages tasks and their statuses.
+# Task Service
+
+Сервис управления задачами и их жизненным циклом.
+
+## Назначение
+
+- создание, изменение и получение задач;
+- хранение данных задач в MongoDB;
+- участие в межсервисном взаимодействии через Eureka/Feign.
+
+## Технологии
+
+- Spring Boot
+- Spring Web
+- Spring Data MongoDB
+- Spring Cloud Config Client
+- Eureka Client
+- OpenFeign
+
+## Порт и healthcheck
+
+- Порт: `8087`
+- Health: `GET http://localhost:8087/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+./mvnw -DskipTests clean package
+```
+
+Если wrapper недоступен:
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d task-service
+docker compose logs -f task-service
+```

--- a/task-service/pom.xml
+++ b/task-service/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring-cloud.version>2023.0.1</spring-cloud.version>
         <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
         <checkstyle.version>10.11.0</checkstyle.version>
@@ -100,6 +100,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[17,18)</version>
+                                    <message>task-service must be built with JDK 17.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/user-service/README.md
+++ b/user-service/README.md
@@ -1,3 +1,49 @@
-# Task tracking and management system
-## Service: User Service
-Manages user information.
+# User Service
+
+Сервис управления пользователями.
+
+## Назначение
+
+- хранение и предоставление данных пользователей;
+- поддержка доменной логики, связанной с пользователями;
+- участие в межсервисных вызовах.
+
+## Технологии
+
+- Spring Boot
+- Spring Web
+- Spring Data MongoDB
+- Spring Cloud Config Client
+- Eureka Client
+
+## Порт и healthcheck
+
+- Порт: `8086`
+- Health: `GET http://localhost:8086/actuator/health`
+
+## Зависимости при запуске
+
+- `mongo`
+- `config-server`
+- `discovery-server`
+
+## Локальная сборка
+
+```bash
+./mvnw -DskipTests clean package
+```
+
+Если wrapper недоступен:
+
+```bash
+mvn -DskipTests clean package
+```
+
+## Запуск в Docker Compose
+
+Из корня репозитория:
+
+```bash
+docker compose up -d user-service
+docker compose logs -f user-service
+```

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring-cloud.version>2023.0.1</spring-cloud.version>
         <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
         <checkstyle.version>10.11.0</checkstyle.version>
@@ -90,6 +90,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[17,18)</version>
+                                    <message>user-service must be built with JDK 17.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- add Maven Enforcer Java version rules to every service module to require JDK 17 and fail fast on mismatched local JDKs
- normalize Maven compiler properties to use `${java.version}` consistently across all service `pom.xml` files
- rewrite root and per-service README files with consistent setup, healthcheck, dependencies, and docker-compose usage guidance

## Test plan
- [x] Verified `comment-service` build fails with explicit enforcer message on JDK 24
- [x] Verified `comment-service` build succeeds on JDK 17
- [x] Rebuilt and started the stack with `docker compose`
- [x] Reviewer validates endpoints using the updated README instructions