### PR TITLE
Add board task filters and backend filtering tests

### DIFF
--- a/page-service/src/main/resources/templates/board.html
+++ b/page-service/src/main/resources/templates/board.html
@@ -177,23 +177,35 @@
 
 <div class="filters">
     <label>Filters:</label>
-    <label for="executorFilter">Author:</label>
-    <select class="filter" id="executorFilter">
+    <label for="authorFilter">Author:</label>
+    <select class="filter" id="authorFilter">
     </select>
 
-    <label for="authorFilter">Executor:</label>
-    <select class="filter" id="authorFilter">
+    <label for="executorFilter">Executor:</label>
+    <select class="filter" id="executorFilter">
     </select>
 
     <label for="reviewerFilter">Reviewer:</label>
     <select class="filter" id="reviewerFilter">
     </select>
 
-    <button class="filter" type="button" th:href="@{/task-management/}">Apply</button>
-    <button class="filter" type="button" th:href="@{/task-management/}">Clear filters</button>
+    <label for="statusFilter">Status:</label>
+    <select class="filter" id="statusFilter">
+        <option value="all">All</option>
+        <option value="open">Open</option>
+        <option value="inQueue">In queue</option>
+        <option value="inWork">In work</option>
+        <option value="onChecking">On checking</option>
+        <option value="completed">Completed</option>
+    </select>
+
+    <button class="filter" id="applyFiltersButton" type="button">Apply</button>
+    <button class="filter" id="clearFiltersButton" type="button">Clear filters</button>
 </div>
 
 <br>
+
+<div id="emptyTasksState"></div>
 
 <div class="tasks">
     <table class="table" id="openTasks">
@@ -257,9 +269,13 @@
     const boardId = document.getElementById('id');
     const boardName = document.getElementById('name');
     const boardOwner = document.getElementById('owner');
-    const boardExecutorFilterSelect = document.getElementById('executorFilter');
     const boardAuthorFilterSelect = document.getElementById('authorFilter');
+    const boardExecutorFilterSelect = document.getElementById('executorFilter');
     const boardReviewerFilterSelect = document.getElementById('reviewerFilter');
+    const boardStatusFilterSelect = document.getElementById('statusFilter');
+    const applyFiltersButton = document.getElementById('applyFiltersButton');
+    const clearFiltersButton = document.getElementById('clearFiltersButton');
+    const emptyTasksState = document.getElementById('emptyTasksState');
 
     const openTasksTable = document.getElementById('openTasks');
     const inQueueTasksTable = document.getElementById('inQueueTasks');
@@ -274,6 +290,8 @@
         }
         uploadCurrentUserToPage();
 
+        applyFiltersButton.addEventListener('click', applyFilters);
+        clearFiltersButton.addEventListener('click', clearFilters);
         uploadBoardToPage();
     }
 
@@ -307,18 +325,21 @@
             .then(board => {
                 boardName.value = board.name;
                 boardOwner.value = board.owner.username;
+                addDefaultFilterOption(boardAuthorFilterSelect);
+                addDefaultFilterOption(boardExecutorFilterSelect);
+                addDefaultFilterOption(boardReviewerFilterSelect);
 
                 let executorsStr = "";
                 board.executors.forEach(user => {
-                    const executorFilterOption = document.createElement('option');
-                    executorFilterOption.value = user.id;
-                    executorFilterOption.textContent = user.username;
-                    boardExecutorFilterSelect.appendChild(executorFilterOption);
-
                     const authorFilterOption = document.createElement('option');
                     authorFilterOption.value = user.id;
                     authorFilterOption.textContent = user.username;
                     boardAuthorFilterSelect.appendChild(authorFilterOption);
+
+                    const executorFilterOption = document.createElement('option');
+                    executorFilterOption.value = user.id;
+                    executorFilterOption.textContent = user.username;
+                    boardExecutorFilterSelect.appendChild(executorFilterOption);
 
                     const reviewerFilterOption = document.createElement('option');
                     reviewerFilterOption.value = user.id;
@@ -336,8 +357,26 @@
             });
     }
 
-    function uploadTasksToPage() {
-        fetch(gateway_host + '/api/task?boardId=' + boardId.value, {
+    function uploadTasksToPage(filters = {}) {
+        clearTaskTables();
+        hideEmptyTasksState();
+
+        const queryParams = new URLSearchParams();
+        queryParams.append('boardId', boardId.value);
+        if (filters.authorId) {
+            queryParams.append('authorId', filters.authorId);
+        }
+        if (filters.executorId) {
+            queryParams.append('executorId', filters.executorId);
+        }
+        if (filters.reviewerId) {
+            queryParams.append('reviewerId', filters.reviewerId);
+        }
+        if (filters.status) {
+            queryParams.append('status', filters.status);
+        }
+
+        fetch(gateway_host + '/api/task?' + queryParams.toString(), {
             method: "GET",
             headers: {
                 'Authorization': `Bearer ${token}`
@@ -345,43 +384,102 @@
             body: null
         })
             .then(response => response.json())
-            .then(tasks => tasks.forEach(task => {
-                let row = openTasksTable.insertRow();
-
-                switch (task.taskStatusValue) {
-                    case 'inQueue':
-                        row = inQueueTasksTable.insertRow();
-                        break;
-                    case 'inWork':
-                        row = inWorkTasksTable.insertRow();
-                        break;
-                    case 'onChecking':
-                        row = onCheckingTasksTable.insertRow();
-                        break;
-                    case 'completed':
-                        row = completedTasksTable.insertRow();
-                        break;
+            .then(tasks => {
+                if (!tasks.length) {
+                    showEmptyTasksState();
+                    return;
                 }
+                tasks.forEach(task => {
+                    let row = openTasksTable.insertRow();
 
-                const taskCell = row.insertCell(0);
+                    switch (task.taskStatusValue) {
+                        case 'inQueue':
+                            row = inQueueTasksTable.insertRow();
+                            break;
+                        case 'inWork':
+                            row = inWorkTasksTable.insertRow();
+                            break;
+                        case 'onChecking':
+                            row = onCheckingTasksTable.insertRow();
+                            break;
+                        case 'completed':
+                            row = completedTasksTable.insertRow();
+                            break;
+                    }
 
-                const taskExecutorLabel = document.createElement('label');
-                taskExecutorLabel.textContent = "Executor: " + task.executor.username;
-                taskExecutorLabel.style.display = 'block';
-                taskCell.appendChild(taskExecutorLabel);
+                    const taskCell = row.insertCell(0);
 
-                const plannedDateLabel = document.createElement('label');
-                plannedDateLabel.textContent = "Planned date: " + task.plannedCompletionDate;
-                plannedDateLabel.style.display = 'block';
-                taskCell.appendChild(plannedDateLabel);
+                    const taskExecutorLabel = document.createElement('label');
+                    taskExecutorLabel.textContent = "Executor: " + task.executor.username;
+                    taskExecutorLabel.style.display = 'block';
+                    taskCell.appendChild(taskExecutorLabel);
 
-                const taskLink = document.createElement('a');
-                taskLink.innerHTML = task.name;
-                taskLink.href = "/task-management" + "/board/" + boardId.value + "/task/" + task.id;
-                taskLink.style.display = 'block';
-                taskCell.appendChild(taskLink);
-            }))
+                    const plannedDateLabel = document.createElement('label');
+                    plannedDateLabel.textContent = "Planned date: " + task.plannedCompletionDate;
+                    plannedDateLabel.style.display = 'block';
+                    taskCell.appendChild(plannedDateLabel);
+
+                    const taskLink = document.createElement('a');
+                    taskLink.innerHTML = task.name;
+                    taskLink.href = "/task-management" + "/board/" + boardId.value + "/task/" + task.id;
+                    taskLink.style.display = 'block';
+                    taskCell.appendChild(taskLink);
+                })
+            })
             .catch(error => console.error(error));
+    }
+
+    function applyFilters() {
+        uploadTasksToPage({
+            authorId: normalizeFilterValue(boardAuthorFilterSelect.value),
+            executorId: normalizeFilterValue(boardExecutorFilterSelect.value),
+            reviewerId: normalizeFilterValue(boardReviewerFilterSelect.value),
+            status: normalizeFilterValue(boardStatusFilterSelect.value)
+        });
+    }
+
+    function clearFilters() {
+        boardAuthorFilterSelect.value = "all";
+        boardExecutorFilterSelect.value = "all";
+        boardReviewerFilterSelect.value = "all";
+        boardStatusFilterSelect.value = "all";
+        uploadTasksToPage();
+    }
+
+    function addDefaultFilterOption(selectElement) {
+        const option = document.createElement('option');
+        option.value = "all";
+        option.textContent = "All";
+        selectElement.appendChild(option);
+    }
+
+    function normalizeFilterValue(value) {
+        if (!value || value === "all") {
+            return null;
+        }
+        return value;
+    }
+
+    function clearTaskTables() {
+        clearTableRows(openTasksTable);
+        clearTableRows(inQueueTasksTable);
+        clearTableRows(inWorkTasksTable);
+        clearTableRows(onCheckingTasksTable);
+        clearTableRows(completedTasksTable);
+    }
+
+    function clearTableRows(tableElement) {
+        while (tableElement.rows.length > 1) {
+            tableElement.deleteRow(1);
+        }
+    }
+
+    function showEmptyTasksState() {
+        emptyTasksState.textContent = "No tasks found for selected filters.";
+    }
+
+    function hideEmptyTasksState() {
+        emptyTasksState.textContent = "";
     }
 </script>
 

--- a/task-service/src/main/java/ru/tasktracking/taskservice/controller/TaskRestController.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/controller/TaskRestController.java
@@ -24,10 +24,24 @@ public class TaskRestController {
     private final TaskService taskService;
 
     @GetMapping("/api/task")
-    public ResponseEntity<List<TaskDto>> getListTasks(@Nullable @RequestParam(name = "boardId") String boardId) {
+    public ResponseEntity<List<TaskDto>> getListTasks(@Nullable @RequestParam(name = "boardId") String boardId,
+                                                       @Nullable @RequestParam(name = "authorId") String authorId,
+                                                       @Nullable @RequestParam(name = "executorId") String executorId,
+                                                       @Nullable @RequestParam(name = "reviewerId") String reviewerId,
+                                                       @Nullable @RequestParam(name = "status") String status) {
         log.info("calling the method: getListTasks");
+        var normalizedAuthorId = normalizeFilter(authorId);
+        var normalizedExecutorId = normalizeFilter(executorId);
+        var normalizedReviewerId = normalizeFilter(reviewerId);
+        var normalizedStatus = normalizeFilter(status);
         if (boardId != null) {
-            return ResponseEntity.ok(TaskDto.toDtoList(taskService.getListOfTasksForBoard(boardId)));
+            return ResponseEntity.ok(TaskDto.toDtoList(taskService.getListOfTasksForBoard(
+                    boardId,
+                    normalizedAuthorId,
+                    normalizedExecutorId,
+                    normalizedReviewerId,
+                    normalizedStatus
+            )));
         }
         return ResponseEntity.ok(TaskDto.toDtoList(taskService.findAll()));
     }
@@ -48,5 +62,12 @@ public class TaskRestController {
     public ResponseEntity<TaskDto> createTask(@RequestBody TaskDto taskDto) {
         log.info("calling the method: createTask");
         return ResponseEntity.ok(new TaskDto(taskService.insert(taskDto)));
+    }
+
+    private String normalizeFilter(String value) {
+        if (value == null || value.isBlank() || "all".equalsIgnoreCase(value)) {
+            return null;
+        }
+        return value;
     }
 }

--- a/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskService.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskService.java
@@ -11,6 +11,8 @@ public interface TaskService {
 
     List<Task> getListOfTasksForBoard(String boardId);
 
+    List<Task> getListOfTasksForBoard(String boardId, String authorId, String executorId, String reviewerId, String status);
+
     Task findById(String id);
 
     Task insert(TaskDto taskDto);

--- a/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskServiceImpl.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskServiceImpl.java
@@ -12,6 +12,7 @@ import ru.tasktracking.taskservice.repository.TaskRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service
@@ -33,7 +34,18 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional(readOnly = true)
     public List<Task> getListOfTasksForBoard(String boardId) {
-        return taskRepository.findAllByBoardId(boardId);
+        return getListOfTasksForBoard(boardId, null, null, null, null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Task> getListOfTasksForBoard(String boardId, String authorId, String executorId, String reviewerId, String status) {
+        return taskRepository.findAllByBoardId(boardId).stream()
+                .filter(task -> authorId == null || Objects.equals(task.getAuthor().getId(), authorId))
+                .filter(task -> executorId == null || Objects.equals(task.getExecutor().getId(), executorId))
+                .filter(task -> reviewerId == null || Objects.equals(task.getReviewer().getId(), reviewerId))
+                .filter(task -> status == null || Objects.equals(task.getTaskStatus().getValue(), status))
+                .toList();
     }
 
     @Override

--- a/task-service/src/test/java/ru/tasktracking/taskservice/controller/TaskRestControllerTest.java
+++ b/task-service/src/test/java/ru/tasktracking/taskservice/controller/TaskRestControllerTest.java
@@ -1,0 +1,90 @@
+package ru.tasktracking.taskservice.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import ru.tasktracking.taskservice.service.TaskService;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TaskRestControllerTest {
+
+    @Mock
+    private TaskService taskService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TaskRestController(taskService)).build();
+    }
+
+    @Test
+    void shouldReturn200AndEmptyArrayWhenNoTasksMatchFilters() throws Exception {
+        when(taskService.getListOfTasksForBoard("board-1", null, null, null, null))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("boardId", "board-1")
+                        .param("authorId", "")
+                        .param("status", "all"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(taskService).getListOfTasksForBoard(
+                eq("board-1"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        );
+    }
+
+    @Test
+    void shouldReturnAllTasksWhenBoardIdIsMissing() throws Exception {
+        when(taskService.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("authorId", "author-1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(taskService).findAll();
+    }
+
+    @Test
+    void shouldNormalizeOptionalFiltersBeforeCallingService() throws Exception {
+        when(taskService.getListOfTasksForBoard("board-1", "author-1", null, null, null))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("boardId", "board-1")
+                        .param("authorId", "author-1")
+                        .param("executorId", "   ")
+                        .param("reviewerId", "all")
+                        .param("status", ""))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(taskService).getListOfTasksForBoard(
+                eq("board-1"),
+                eq("author-1"),
+                isNull(),
+                isNull(),
+                isNull()
+        );
+    }
+}

--- a/task-service/src/test/java/ru/tasktracking/taskservice/service/TaskServiceImplTest.java
+++ b/task-service/src/test/java/ru/tasktracking/taskservice/service/TaskServiceImplTest.java
@@ -1,0 +1,118 @@
+package ru.tasktracking.taskservice.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.tasktracking.taskservice.domain.Board;
+import ru.tasktracking.taskservice.domain.Task;
+import ru.tasktracking.taskservice.domain.TaskStatus;
+import ru.tasktracking.taskservice.domain.User;
+import ru.tasktracking.taskservice.repository.TaskRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceImplTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private BoardService boardService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private TaskServiceImpl taskService;
+
+    @Test
+    void shouldFilterByAndCombination() {
+        when(taskRepository.findAllByBoardId("board-1"))
+                .thenReturn(List.of(
+                        task("task-1", "board-1", "author-1", "exec-1", "review-1", "inWork"),
+                        task("task-2", "board-1", "author-1", "exec-2", "review-1", "inQueue"),
+                        task("task-3", "board-1", "author-2", "exec-1", "review-2", "inWork")
+                ));
+
+        List<Task> filteredTasks = taskService.getListOfTasksForBoard(
+                "board-1",
+                "author-1",
+                null,
+                null,
+                "inWork"
+        );
+
+        assertThat(filteredTasks)
+                .hasSize(1)
+                .extracting(Task::getId)
+                .containsExactly("task-1");
+    }
+
+    @Test
+    void shouldReturnAllTasksWhenOptionalFiltersAreMissing() {
+        when(taskRepository.findAllByBoardId("board-1"))
+                .thenReturn(List.of(
+                        task("task-1", "board-1", "author-1", "exec-1", "review-1", "open"),
+                        task("task-2", "board-1", "author-2", "exec-2", "review-2", "completed")
+                ));
+
+        List<Task> filteredTasks = taskService.getListOfTasksForBoard(
+                "board-1",
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThat(filteredTasks)
+                .hasSize(2)
+                .extracting(Task::getId)
+                .containsExactly("task-1", "task-2");
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoTasksMatchFilters() {
+        when(taskRepository.findAllByBoardId("board-1"))
+                .thenReturn(List.of(
+                        task("task-1", "board-1", "author-1", "exec-1", "review-1", "open"),
+                        task("task-2", "board-1", "author-2", "exec-2", "review-2", "completed")
+                ));
+
+        List<Task> filteredTasks = taskService.getListOfTasksForBoard(
+                "board-1",
+                "author-1",
+                null,
+                null,
+                "inWork"
+        );
+
+        assertThat(filteredTasks).isEmpty();
+    }
+
+    private Task task(String id,
+                      String boardId,
+                      String authorId,
+                      String executorId,
+                      String reviewerId,
+                      String statusValue) {
+        return new Task(
+                id,
+                "Task " + id,
+                "Describe",
+                new Board(boardId, "Board"),
+                new User(authorId, "Author"),
+                new User(executorId, "Executor"),
+                new User(reviewerId, "Reviewer"),
+                null,
+                null,
+                null,
+                TaskStatus.findByValue(statusValue)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add author/executor/reviewer/status filters to the board UI and empty-state handling
- extend task API and service logic to support optional board-level filtering by all selected fields
- add controller and service tests for filter normalization and AND-based filtering behavior

## Test plan
- [x] Run `sh ./mvnw test` in `task-service` with JDK 17
- [x] Rebuild `task-service` and `page-service`
- [x] Rebuild and restart `task-service` and `page-service` containers