### PR TITLE
PET-8: Board task filters

### DIFF
--- a/page-service/src/main/resources/static/css/jira-like.css
+++ b/page-service/src/main/resources/static/css/jira-like.css
@@ -976,6 +976,20 @@ a.btn {
     margin-bottom: 0;
 }
 
+.board-filter-empty-state {
+    margin: 12px 0 0;
+    padding: 12px 14px;
+    background: #fff7d6;
+    border: 1px solid #f5cd47;
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 14px;
+}
+
+.board-filter-empty-state[hidden] {
+    display: none;
+}
+
 .board-main .kanban-board {
     margin-top: 8px;
     display: grid;

--- a/page-service/src/main/resources/templates/board.html
+++ b/page-service/src/main/resources/templates/board.html
@@ -93,21 +93,25 @@
             <h2 class="section-title">Filters</h2>
             <div class="filters-bar">
                 <div class="filter-group">
-                    <label for="executorFilter">Author:</label>
-                    <select class="filter-select" id="executorFilter"></select>
+                    <label for="authorFilter">Author:</label>
+                    <select class="filter-select" id="authorFilter"></select>
                 </div>
                 <div class="filter-group">
-                    <label for="authorFilter">Executor:</label>
-                    <select class="filter-select" id="authorFilter"></select>
+                    <label for="executorFilter">Executor:</label>
+                    <select class="filter-select" id="executorFilter"></select>
                 </div>
                 <div class="filter-group">
                     <label for="reviewerFilter">Reviewer:</label>
                     <select class="filter-select" id="reviewerFilter"></select>
                 </div>
                 <div class="filter-actions">
-                    <button class="btn btn-primary" type="button" onclick="applyBoardFiltersStub()">Apply</button>
-                    <button class="btn btn-subtle" type="button" onclick="clearBoardFiltersStub()">Clear filters</button>
+                    <button class="btn btn-primary" type="button" onclick="applyBoardFilters()">Apply</button>
+                    <button class="btn btn-subtle" type="button" onclick="clearBoardFilters()">Clear filters</button>
                 </div>
+            </div>
+
+            <div id="boardFilterEmptyState" class="board-filter-empty-state" hidden>
+                No tasks match the selected filters.
             </div>
 
             <h2 class="section-title">Tasks</h2>
@@ -162,9 +166,10 @@
     const boardId = document.getElementById('id');
     const boardName = document.getElementById('name');
     const boardOwner = document.getElementById('owner');
-    const boardExecutorFilterSelect = document.getElementById('executorFilter');
     const boardAuthorFilterSelect = document.getElementById('authorFilter');
+    const boardExecutorFilterSelect = document.getElementById('executorFilter');
     const boardReviewerFilterSelect = document.getElementById('reviewerFilter');
+    const boardFilterEmptyState = document.getElementById('boardFilterEmptyState');
 
     const columnLists = {
         open: document.getElementById('openTasksList'),
@@ -182,12 +187,82 @@
         completed: document.getElementById('completedTasksCount')
     };
 
-    function applyBoardFiltersStub() {
-        showFeatureNotImplemented('Board filters');
+    function initFilterSelects() {
+        [boardAuthorFilterSelect, boardExecutorFilterSelect, boardReviewerFilterSelect].forEach(select => {
+            const emptyOption = document.createElement('option');
+            emptyOption.value = '';
+            emptyOption.textContent = 'All';
+            select.appendChild(emptyOption);
+        });
+
+        const authorUnassignedOption = document.createElement('option');
+        authorUnassignedOption.value = 'UNASSIGNED';
+        authorUnassignedOption.textContent = 'Not selected';
+        boardAuthorFilterSelect.appendChild(authorUnassignedOption);
+
+        const reviewerUnassignedOption = document.createElement('option');
+        reviewerUnassignedOption.value = 'UNASSIGNED';
+        reviewerUnassignedOption.textContent = 'Not selected';
+        boardReviewerFilterSelect.appendChild(reviewerUnassignedOption);
     }
 
-    function clearBoardFiltersStub() {
-        showFeatureNotImplemented('Board filters');
+    function resetFilterSelects() {
+        [boardAuthorFilterSelect, boardExecutorFilterSelect, boardReviewerFilterSelect].forEach(select => {
+            select.innerHTML = '';
+        });
+        initFilterSelects();
+    }
+
+    function populateFilterUserOptions(users) {
+        users.forEach(user => {
+            [boardAuthorFilterSelect, boardExecutorFilterSelect, boardReviewerFilterSelect].forEach(select => {
+                const option = document.createElement('option');
+                option.value = user.id;
+                option.textContent = user.username;
+                select.appendChild(option);
+            });
+        });
+    }
+
+    function hasActiveBoardFilters() {
+        return boardAuthorFilterSelect.value !== ''
+            || boardExecutorFilterSelect.value !== ''
+            || boardReviewerFilterSelect.value !== '';
+    }
+
+    function buildTaskUrl() {
+        const params = new URLSearchParams();
+        params.set('boardId', boardId.value);
+        if (boardAuthorFilterSelect.value) {
+            params.set('authorId', boardAuthorFilterSelect.value);
+        }
+        if (boardExecutorFilterSelect.value) {
+            params.set('executorId', boardExecutorFilterSelect.value);
+        }
+        if (boardReviewerFilterSelect.value) {
+            params.set('reviewerId', boardReviewerFilterSelect.value);
+        }
+        return gateway_host + '/api/task?' + params.toString();
+    }
+
+    function showBoardFilterEmptyState() {
+        boardFilterEmptyState.hidden = false;
+    }
+
+    function hideBoardFilterEmptyState() {
+        boardFilterEmptyState.hidden = true;
+    }
+
+    function applyBoardFilters() {
+        loadBoardTasks(buildTaskUrl());
+    }
+
+    function clearBoardFilters() {
+        boardAuthorFilterSelect.value = '';
+        boardExecutorFilterSelect.value = '';
+        boardReviewerFilterSelect.value = '';
+        hideBoardFilterEmptyState();
+        loadBoardTasks();
     }
 
     function boardTaskSearchStub() {
@@ -242,27 +317,14 @@
 
                 const executorsList = document.getElementById('executorsList');
                 executorsList.innerHTML = '';
+                resetFilterSelects();
                 board.executors.forEach(user => {
-                    const executorFilterOption = document.createElement('option');
-                    executorFilterOption.value = user.id;
-                    executorFilterOption.textContent = user.username;
-                    boardExecutorFilterSelect.appendChild(executorFilterOption);
-
-                    const authorFilterOption = document.createElement('option');
-                    authorFilterOption.value = user.id;
-                    authorFilterOption.textContent = user.username;
-                    boardAuthorFilterSelect.appendChild(authorFilterOption);
-
-                    const reviewerFilterOption = document.createElement('option');
-                    reviewerFilterOption.value = user.id;
-                    reviewerFilterOption.textContent = user.username;
-                    boardReviewerFilterSelect.appendChild(reviewerFilterOption);
-
                     const li = document.createElement('li');
                     li.textContent = user.username;
                     executorsList.appendChild(li);
                 });
-                uploadTasksToPage();
+                populateFilterUserOptions(board.executors);
+                loadBoardTasks();
             })
             .catch(error => {
                 console.error(error);
@@ -307,9 +369,37 @@
         columnCounts.completed.textContent = String(columnLists.completed.children.length);
     }
 
-    function uploadTasksToPage() {
+    function renderTasks(tasks) {
         clearKanban();
-        fetch(gateway_host + '/api/task?boardId=' + boardId.value, {
+        tasks.forEach(task => {
+            let target = columnLists.open;
+            switch (task.taskStatusValue) {
+                case 'inQueue':
+                    target = columnLists.inQueue;
+                    break;
+                case 'inWork':
+                    target = columnLists.inWork;
+                    break;
+                case 'onChecking':
+                    target = columnLists.onChecking;
+                    break;
+                case 'completed':
+                    target = columnLists.completed;
+                    break;
+            }
+            target.appendChild(createTaskCard(task));
+        });
+        updateColumnCounts();
+        if (tasks.length === 0 && hasActiveBoardFilters()) {
+            showBoardFilterEmptyState();
+        } else {
+            hideBoardFilterEmptyState();
+        }
+    }
+
+    function loadBoardTasks(url) {
+        const taskUrl = url || (gateway_host + '/api/task?boardId=' + encodeURIComponent(boardId.value));
+        fetch(taskUrl, {
             method: "GET",
             headers: {
                 'Authorization': `Bearer ${token}`
@@ -317,27 +407,7 @@
             body: null
         })
             .then(response => response.json())
-            .then(tasks => {
-                tasks.forEach(task => {
-                    let target = columnLists.open;
-                    switch (task.taskStatusValue) {
-                        case 'inQueue':
-                            target = columnLists.inQueue;
-                            break;
-                        case 'inWork':
-                            target = columnLists.inWork;
-                            break;
-                        case 'onChecking':
-                            target = columnLists.onChecking;
-                            break;
-                        case 'completed':
-                            target = columnLists.completed;
-                            break;
-                    }
-                    target.appendChild(createTaskCard(task));
-                });
-                updateColumnCounts();
-            })
+            .then(tasks => renderTasks(tasks))
             .catch(error => console.error(error));
     }
 </script>

--- a/task-service/src/main/java/ru/tasktracking/taskservice/controller/TaskRestController.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/controller/TaskRestController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import ru.tasktracking.taskservice.dto.TaskDto;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
 import ru.tasktracking.taskservice.service.TaskService;
 
 import java.util.List;
@@ -24,8 +25,17 @@ public class TaskRestController {
     private final TaskService taskService;
 
     @GetMapping("/api/task")
-    public ResponseEntity<List<TaskDto>> getListTasks(@Nullable @RequestParam(name = "boardId") String boardId) {
+    public ResponseEntity<List<TaskDto>> getListTasks(
+            @Nullable @RequestParam(name = "boardId") String boardId,
+            @Nullable @RequestParam(name = "authorId") String authorId,
+            @Nullable @RequestParam(name = "executorId") String executorId,
+            @Nullable @RequestParam(name = "reviewerId") String reviewerId
+    ) {
         log.info("calling the method: getListTasks");
+        if (boardId != null && TaskBoardFilter.hasFilterParams(authorId, executorId, reviewerId)) {
+            var filter = TaskBoardFilter.fromQuery(boardId, authorId, executorId, reviewerId);
+            return ResponseEntity.ok(TaskDto.toDtoList(taskService.getFilteredTasksForBoard(filter)));
+        }
         if (boardId != null) {
             return ResponseEntity.ok(TaskDto.toDtoList(taskService.getListOfTasksForBoard(boardId)));
         }

--- a/task-service/src/main/java/ru/tasktracking/taskservice/filter/TaskBoardFilter.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/filter/TaskBoardFilter.java
@@ -1,0 +1,56 @@
+package ru.tasktracking.taskservice.filter;
+
+import java.util.Optional;
+
+import static ru.tasktracking.taskservice.filter.TaskFilterConstants.UNASSIGNED;
+
+public record TaskBoardFilter(
+        String boardId,
+        Optional<String> authorId,
+        boolean authorUnassigned,
+        Optional<String> executorId,
+        Optional<String> reviewerId,
+        boolean reviewerUnassigned
+) {
+
+    public boolean hasFilters() {
+        return authorUnassigned
+                || reviewerUnassigned
+                || authorId.isPresent()
+                || executorId.isPresent()
+                || reviewerId.isPresent();
+    }
+
+    public static boolean hasFilterParams(String authorId, String executorId, String reviewerId) {
+        return isPresent(authorId) || isPresent(executorId) || isPresent(reviewerId);
+    }
+
+    public static TaskBoardFilter fromQuery(
+            String boardId,
+            String authorId,
+            String executorId,
+            String reviewerId
+    ) {
+        boolean authorUnassigned = UNASSIGNED.equals(authorId);
+        boolean reviewerUnassigned = UNASSIGNED.equals(reviewerId);
+        return new TaskBoardFilter(
+                boardId,
+                parseUserId(authorId, authorUnassigned),
+                authorUnassigned,
+                parseUserId(executorId, false),
+                parseUserId(reviewerId, reviewerUnassigned),
+                reviewerUnassigned
+        );
+    }
+
+    private static Optional<String> parseUserId(String raw, boolean unassignedSentinel) {
+        if (raw == null || raw.isBlank() || unassignedSentinel || UNASSIGNED.equals(raw)) {
+            return Optional.empty();
+        }
+        return Optional.of(raw.trim());
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/task-service/src/main/java/ru/tasktracking/taskservice/filter/TaskFilterConstants.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/filter/TaskFilterConstants.java
@@ -1,0 +1,9 @@
+package ru.tasktracking.taskservice.filter;
+
+public final class TaskFilterConstants {
+
+    public static final String UNASSIGNED = "UNASSIGNED";
+
+    private TaskFilterConstants() {
+    }
+}

--- a/task-service/src/main/java/ru/tasktracking/taskservice/repository/MongoDbRefCriteria.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/repository/MongoDbRefCriteria.java
@@ -1,0 +1,17 @@
+package ru.tasktracking.taskservice.repository;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+final class MongoDbRefCriteria {
+
+    private MongoDbRefCriteria() {
+    }
+
+    static Criteria idEquals(String refField, String id) {
+        if (ObjectId.isValid(id)) {
+            return Criteria.where(refField + ".$id").is(new ObjectId(id));
+        }
+        return Criteria.where(refField + ".$id").is(id);
+    }
+}

--- a/task-service/src/main/java/ru/tasktracking/taskservice/repository/TaskRepository.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/repository/TaskRepository.java
@@ -5,7 +5,7 @@ import ru.tasktracking.taskservice.domain.Task;
 
 import java.util.List;
 
-public interface TaskRepository extends MongoRepository<Task, String> {
+public interface TaskRepository extends MongoRepository<Task, String>, TaskRepositoryCustom {
 
     List<Task> findAllByBoardId(String boardId);
 }

--- a/task-service/src/main/java/ru/tasktracking/taskservice/repository/TaskRepositoryCustom.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/repository/TaskRepositoryCustom.java
@@ -1,0 +1,11 @@
+package ru.tasktracking.taskservice.repository;
+
+import ru.tasktracking.taskservice.domain.Task;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
+
+import java.util.List;
+
+public interface TaskRepositoryCustom {
+
+    List<Task> findByBoardFilter(TaskBoardFilter filter);
+}

--- a/task-service/src/main/java/ru/tasktracking/taskservice/repository/TaskRepositoryImpl.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/repository/TaskRepositoryImpl.java
@@ -1,0 +1,51 @@
+package ru.tasktracking.taskservice.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+import ru.tasktracking.taskservice.domain.Task;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TaskRepositoryImpl implements TaskRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public List<Task> findByBoardFilter(TaskBoardFilter filter) {
+        List<Criteria> criteriaList = new ArrayList<>();
+        criteriaList.add(MongoDbRefCriteria.idEquals("board", filter.boardId()));
+
+        if (filter.authorUnassigned()) {
+            criteriaList.add(unassignedFieldCriteria("author"));
+        } else if (filter.authorId().isPresent()) {
+            criteriaList.add(MongoDbRefCriteria.idEquals("author", filter.authorId().get()));
+        }
+
+        if (filter.executorId().isPresent()) {
+            criteriaList.add(MongoDbRefCriteria.idEquals("executor", filter.executorId().get()));
+        }
+
+        if (filter.reviewerUnassigned()) {
+            criteriaList.add(unassignedFieldCriteria("reviewer"));
+        } else if (filter.reviewerId().isPresent()) {
+            criteriaList.add(MongoDbRefCriteria.idEquals("reviewer", filter.reviewerId().get()));
+        }
+
+        Criteria combined = new Criteria().andOperator(criteriaList.toArray(Criteria[]::new));
+        return mongoTemplate.find(new Query(combined), Task.class);
+    }
+
+    private Criteria unassignedFieldCriteria(String field) {
+        return new Criteria().orOperator(
+                Criteria.where(field).is(null),
+                Criteria.where(field).exists(false)
+        );
+    }
+}

--- a/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskService.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskService.java
@@ -2,6 +2,7 @@ package ru.tasktracking.taskservice.service;
 
 import ru.tasktracking.taskservice.domain.Task;
 import ru.tasktracking.taskservice.dto.TaskDto;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
 
 import java.util.List;
 
@@ -10,6 +11,8 @@ public interface TaskService {
     List<Task> findAll();
 
     List<Task> getListOfTasksForBoard(String boardId);
+
+    List<Task> getFilteredTasksForBoard(TaskBoardFilter filter);
 
     Task findById(String id);
 

--- a/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskServiceImpl.java
+++ b/task-service/src/main/java/ru/tasktracking/taskservice/service/TaskServiceImpl.java
@@ -8,6 +8,7 @@ import ru.tasktracking.taskservice.domain.Task;
 import ru.tasktracking.taskservice.domain.TaskStatus;
 import ru.tasktracking.taskservice.dto.TaskDto;
 import ru.tasktracking.taskservice.exception.EntityNotFoundException;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
 import ru.tasktracking.taskservice.repository.TaskRepository;
 
 import java.time.LocalDate;
@@ -34,6 +35,15 @@ public class TaskServiceImpl implements TaskService {
     @Transactional(readOnly = true)
     public List<Task> getListOfTasksForBoard(String boardId) {
         return taskRepository.findAllByBoardId(boardId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Task> getFilteredTasksForBoard(TaskBoardFilter filter) {
+        if (!filter.hasFilters()) {
+            return taskRepository.findAllByBoardId(filter.boardId());
+        }
+        return taskRepository.findByBoardFilter(filter);
     }
 
     @Override

--- a/task-service/src/test/java/ru/tasktracking/taskservice/controller/TaskRestControllerFilterTest.java
+++ b/task-service/src/test/java/ru/tasktracking/taskservice/controller/TaskRestControllerFilterTest.java
@@ -1,0 +1,112 @@
+package ru.tasktracking.taskservice.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
+import ru.tasktracking.taskservice.service.TaskService;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TaskRestControllerFilterTest {
+
+    @Mock
+    private TaskService taskService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TaskRestController(taskService)).build();
+    }
+
+    @Test
+    void getListTasks_shouldUseFilteredPathForExecutorId() throws Exception {
+        when(taskService.getFilteredTasksForBoard(argThat(filter ->
+                "board-1".equals(filter.boardId())
+                        && filter.executorId().equals(Optional.of("executor-1"))
+        ))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("boardId", "board-1")
+                        .param("executorId", "executor-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+
+        verify(taskService).getFilteredTasksForBoard(argThat(filter ->
+                "board-1".equals(filter.boardId())
+                        && filter.executorId().equals(Optional.of("executor-1"))
+        ));
+    }
+
+    @Test
+    void getListTasks_shouldCombineAuthorAndExecutorFilters() throws Exception {
+        when(taskService.getFilteredTasksForBoard(argThat(filter ->
+                filter.authorId().equals(Optional.of("author-1"))
+                        && filter.executorId().equals(Optional.of("executor-1"))
+        ))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("boardId", "board-1")
+                        .param("authorId", "author-1")
+                        .param("executorId", "executor-1"))
+                .andExpect(status().isOk());
+
+        verify(taskService).getFilteredTasksForBoard(argThat(filter ->
+                filter.authorId().equals(Optional.of("author-1"))
+                        && filter.executorId().equals(Optional.of("executor-1"))
+        ));
+    }
+
+    @Test
+    void getListTasks_shouldParseReviewerUnassignedSentinel() throws Exception {
+        when(taskService.getFilteredTasksForBoard(argThat(TaskBoardFilter::reviewerUnassigned)))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("boardId", "board-1")
+                        .param("reviewerId", "UNASSIGNED"))
+                .andExpect(status().isOk());
+
+        verify(taskService).getFilteredTasksForBoard(argThat(filter ->
+                filter.reviewerUnassigned() && filter.reviewerId().isEmpty()
+        ));
+    }
+
+    @Test
+    void getListTasks_shouldReturnEmptyArrayWhenNoMatches() throws Exception {
+        when(taskService.getFilteredTasksForBoard(argThat(filter ->
+                filter.authorId().equals(Optional.of("missing-author"))
+        ))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task")
+                        .param("boardId", "board-1")
+                        .param("authorId", "missing-author")
+                        .param("executorId", "missing-executor"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void getListTasks_shouldUseBoardPathWithoutFilters() throws Exception {
+        when(taskService.getListOfTasksForBoard("board-1")).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/task").param("boardId", "board-1"))
+                .andExpect(status().isOk());
+
+        verify(taskService).getListOfTasksForBoard("board-1");
+    }
+}

--- a/task-service/src/test/java/ru/tasktracking/taskservice/filter/TaskBoardFilterTest.java
+++ b/task-service/src/test/java/ru/tasktracking/taskservice/filter/TaskBoardFilterTest.java
@@ -1,0 +1,34 @@
+package ru.tasktracking.taskservice.filter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskBoardFilterTest {
+
+    @Test
+    void fromQuery_shouldParseUnassignedReviewer() {
+        var filter = TaskBoardFilter.fromQuery("board-1", null, null, "UNASSIGNED");
+
+        assertThat(filter.reviewerUnassigned()).isTrue();
+        assertThat(filter.reviewerId()).isEmpty();
+        assertThat(filter.hasFilters()).isTrue();
+    }
+
+    @Test
+    void fromQuery_shouldParseUserIds() {
+        var filter = TaskBoardFilter.fromQuery("board-1", "author-1", "executor-1", null);
+
+        assertThat(filter.authorId()).contains("author-1");
+        assertThat(filter.executorId()).contains("executor-1");
+        assertThat(filter.authorUnassigned()).isFalse();
+    }
+
+    @Test
+    void hasFilterParams_shouldDetectAnyFilter() {
+        assertThat(TaskBoardFilter.hasFilterParams(null, "executor-1", null)).isTrue();
+        assertThat(TaskBoardFilter.hasFilterParams("", "", "")).isFalse();
+    }
+}

--- a/task-service/src/test/java/ru/tasktracking/taskservice/repository/MongoDbRefCriteriaTest.java
+++ b/task-service/src/test/java/ru/tasktracking/taskservice/repository/MongoDbRefCriteriaTest.java
@@ -1,0 +1,30 @@
+package ru.tasktracking.taskservice.repository;
+
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MongoDbRefCriteriaTest {
+
+    @Test
+    void idEquals_shouldUseObjectIdForHexId() {
+        String id = "6a0711a32081ae6089826a74";
+        Criteria criteria = MongoDbRefCriteria.idEquals("executor", id);
+        Document query = new Query(criteria).getQueryObject();
+
+        assertThat(query.get("executor.$id")).isEqualTo(new ObjectId(id));
+    }
+
+    @Test
+    void idEquals_shouldKeepStringForNonObjectId() {
+        String id = "not-an-object-id";
+        Criteria criteria = MongoDbRefCriteria.idEquals("executor", id);
+        Document query = new Query(criteria).getQueryObject();
+
+        assertThat(query.get("executor.$id")).isEqualTo(id);
+    }
+}

--- a/task-service/src/test/java/ru/tasktracking/taskservice/service/TaskServiceImplFilterTest.java
+++ b/task-service/src/test/java/ru/tasktracking/taskservice/service/TaskServiceImplFilterTest.java
@@ -1,0 +1,92 @@
+package ru.tasktracking.taskservice.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.tasktracking.taskservice.domain.Task;
+import ru.tasktracking.taskservice.filter.TaskBoardFilter;
+import ru.tasktracking.taskservice.repository.TaskRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceImplFilterTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private BoardService boardService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private TaskServiceImpl taskService;
+
+    @Test
+    void getFilteredTasksForBoard_shouldDelegateToRepositoryWhenFiltersPresent() {
+        var filter = new TaskBoardFilter(
+                "board-1",
+                Optional.empty(),
+                false,
+                Optional.of("executor-1"),
+                Optional.empty(),
+                false
+        );
+        var tasks = List.of(new Task());
+        when(taskRepository.findByBoardFilter(filter)).thenReturn(tasks);
+
+        var result = taskService.getFilteredTasksForBoard(filter);
+
+        assertThat(result).isEqualTo(tasks);
+        verify(taskRepository).findByBoardFilter(filter);
+        verifyNoMoreInteractions(taskRepository);
+    }
+
+    @Test
+    void getFilteredTasksForBoard_shouldUseFindAllByBoardIdWhenNoFilters() {
+        var filter = new TaskBoardFilter(
+                "board-1",
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                Optional.empty(),
+                false
+        );
+        var tasks = List.of(new Task());
+        when(taskRepository.findAllByBoardId("board-1")).thenReturn(tasks);
+
+        var result = taskService.getFilteredTasksForBoard(filter);
+
+        assertThat(result).isEqualTo(tasks);
+        verify(taskRepository).findAllByBoardId("board-1");
+        verifyNoMoreInteractions(taskRepository);
+    }
+
+    @Test
+    void getFilteredTasksForBoard_shouldSupportReviewerUnassignedFilter() {
+        var filter = new TaskBoardFilter(
+                "board-1",
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                Optional.empty(),
+                true
+        );
+        when(taskRepository.findByBoardFilter(filter)).thenReturn(List.of());
+
+        var result = taskService.getFilteredTasksForBoard(filter);
+
+        assertThat(result).isEmpty();
+        verify(taskRepository).findByBoardFilter(filter);
+    }
+}


### PR DESCRIPTION
Adds server-side filtering for kanban board tasks.

API: GET /api/task accepts optional authorId, executorId, and reviewerId (with boardId). Filters combine with AND logic. UNASSIGNED means no author/reviewer.

Backend: MongoDB Criteria via custom repository; DBRef queries use ObjectId for $id fields.

UI: Fixed filter labels, Apply/Clear, empty state, column counts reflect filtered results.

Tests: Unit tests for filter parsing, service, controller, and DBRef criteria.